### PR TITLE
Reduced Makefile size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,163 +1,38 @@
-default_target: bpee
-.PHONY : default_target
-
-TARGET = $@
-
-BPEEpointer=$(shell printf "%d" 0x2E00F0)
-BPEDpointer=$(shell printf "%d" 0x2F5E30)
-BPREpointer=$(shell printf "%d" 0x1DD0B4)
-BPGEpointer=$(shell printf "%d" 0x1DD090)
-
-ifdef offset
-INSERT=$(shell printf "%d" 0x$(offset))
-encodedoffset=$(shell sed -e 's/\(..\)\(..\)\(..\)/\\\x\3\\\x\2\\\x\1/' <<< "$(offset)")
+.DEFAULT_GOAL := bpee
+ifdef MAKECMDGOALS
+CURRENT_GOAL = $(MAKECMDGOALS)
+else
+CURRENT_GOAL = $(.DEFAULT_GOAL)
 endif
 
-PATH      := /opt/devkitpro/devkitARM/bin:$(PATH)
-OPTS := -fauto-inc-dec -fcompare-elim -fcprop-registers -fdce -fdefer-pop -fdelayed-branch -fdse -fguess-branch-probability -fif-conversion2 -fif-conversion -fipa-pure-const -fipa-profile -fipa-reference -fmerge-constants -fsplit-wide-types -ftree-bit-ccp -ftree-builtin-call-dce -ftree-ccp -ftree-ch -ftree-copyrename -ftree-dce -ftree-dominator-opts -ftree-dse -ftree-forwprop -ftree-fre -ftree-phiprop -ftree-sra -ftree-pta -ftree-ter -funit-at-a-time -fomit-frame-pointer -fthread-jumps -falign-functions -falign-jumps -falign-loops  -falign-labels -fcaller-saves -fcrossjumping -fcse-follow-jumps  -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fexpensive-optimizations -fgcse -fgcse-lm -finline-small-functions -findirect-inlining -fipa-sra -foptimize-sibling-calls -fpartial-inlining -fpeephole2 -fregmove -freorder-blocks -freorder-functions -frerun-cse-after-loop -fsched-interblock -fsched-spec -fschedule-insns -fschedule-insns2 -fstrict-aliasing -fstrict-overflow -ftree-switch-conversion -ftree-tail-merge -ftree-pre -ftree-vrp -finline-functions -funswitch-loops -fpredictive-commoning -fgcse-after-reload -ftree-slp-vectorize -fvect-cost-model -fipa-cp-clone -ffast-math -fno-protect-parens -fstack-arrays -fforward-propagate -finline-functions-called-once -fmerge-all-constants -fmodulo-sched -fmodulo-sched-allow-regmoves -fgcse-sm -fgcse-las -funsafe-loop-optimizations -fconserve-stack
+BPEEpointer = $(shell printf "%d" 0x2E00F0)
+BPEDpointer = $(shell printf "%d" 0x2F5E30)
+BPREpointer = $(shell printf "%d" 0x1DD0B4)
+BPGEpointer = $(shell printf "%d" 0x1DD090)
 
-bpee : 
-	sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
-	cp main.s main-bpee.s
-	arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-bpee.out main-bpee.s
-	arm-none-eabi-ld -o main-bpee.o -T linker.lsc main-bpee.out
-	arm-none-eabi-objcopy -O binary main-bpee.o main-bpee.bin
-	rm main-bpee.s
-	rm main-bpee.o
-	rm main-bpee.out
-	rm linker.lsc
+PATH := /opt/devkitpro/devkitARM/bin:$(PATH)
+OPTS := -fauto-inc-dec -fcompare-elim -fcprop-registers -fdce -fdefer-pop -fdelayed-branch -fdse -fguess-branch-probability -fif-conversion2 -fif-conversion -fipa-pure-const -fipa-profile -fipa-reference -fmerge-constants -fsplit-wide-types -ftree-bit-ccp -ftree-builtin-call-dce -ftree-ccp -ftree-ch -ftree-copyrename -ftree-dce -ftree-dominator-opts -ftree-dse -ftree-forwprop -ftree-fre -ftree-phiprop -ftree-sra -ftree-pta -ftree-ter -funit-at-a-time -fomit-frame-pointer -fthread-jumps -falign-functions -falign-jumps -falign-loops -falign-labels -fcaller-saves -fcrossjumping -fcse-follow-jumps  -fcse-skip-blocks -fdelete-null-pointer-checks -fdevirtualize -fexpensive-optimizations -fgcse -fgcse-lm -finline-small-functions -findirect-inlining -fipa-sra -foptimize-sibling-calls -fpartial-inlining -fpeephole2 -fregmove -freorder-blocks -freorder-functions -frerun-cse-after-loop -fsched-interblock -fsched-spec -fschedule-insns -fschedule-insns2 -fstrict-aliasing -fstrict-overflow -ftree-switch-conversion -ftree-tail-merge -ftree-pre -ftree-vrp -finline-functions -funswitch-loops -fpredictive-commoning -fgcse-after-reload -ftree-slp-vectorize -fvect-cost-model -fipa-cp-clone -ffast-math -fno-protect-parens -fstack-arrays -fforward-propagate -finline-functions-called-once -fmerge-all-constants -fmodulo-sched -fmodulo-sched-allow-regmoves -fgcse-sm -fgcse-las -funsafe-loop-optimizations -fconserve-stack
+
+%::
+	@sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
+	@sed 's/^    .equ    USED_GAME, GAME_SELECTION/    .equ    USED_GAME, GAME_$(shell echo $@ | tr a-z A-Z)/' main.s > main-$@.s
+	@arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-$@.out main-$@.s
+	@arm-none-eabi-ld -o main-$@.o -T linker.lsc main-$@.out
+	@arm-none-eabi-objcopy -O binary main-$@.o main-$@.bin
+	@rm main-$@.{s,o,out} linker.lsc
 
 #Auto-Insert into the ROM
-ifdef rom
-ifdef INSERT
-	dd if=main-bpee.bin of="$(rom)" conv=notrunc seek=$(INSERT) bs=1
-	printf '$(encodedoffset)\x08' | dd of="$(rom)" conv=notrunc seek=$(BPEEpointer) bs=1
-else
-	@echo "Injection location not found!"
-	@echo "Did you forget to define 'offset'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
+ifndef rom
+	@echo -e "File location not found!\nDid you forget to define 'rom'?\nEx: make <game id> rom=<game.gba> offset=<offset in hex>"
+else # rom is defined
+ifndef offset
+	@echo -e "Injection location not found!\nDid you forget to define 'offset'?\nEx: make <game id> rom=<game.gba> offset=<offset in hex>"
+else # offset is defined
+	@dd if=main-$@.bin of="$(rom)" conv=notrunc seek=$(shell printf "%d" 0x$(offset)) bs=1
+ifneq ($(CURRENT_GOAL),kwj6) # goal is bpee, bped, bpeg or bpre
+	@printf '$(shell sed -e 's/\(..\)\(..\)\(..\)/\\\x\3\\\x\2\\\x\1/' <<< "$(offset)")\x08' | dd of="$(rom)" conv=notrunc seek=$($(shell echo $@ | tr a-z A-Z)pointer) bs=1
+else # goal is kwj6
+	@echo -e "Pointer location for build target $@ is unknown, it cannot be automatically patched.\nPlease change the pointer manually."
 endif
-else
-	@echo "File location not found!"
-	@echo "Did you forget to define 'rom'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
 endif
-
-.PHONY : bped
-
-bped : 
-	sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
-	sed 's/^    .equ    USED_GAME, GAME_BPEE/    .equ    USED_GAME, GAME_BPED/' main.s > main-bped.s
-	arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-bped.out main-bped.s
-	arm-none-eabi-ld -o main-bped.o -T linker.lsc main-bped.out
-	arm-none-eabi-objcopy -O binary main-bped.o main-bped.bin
-	rm main-bped.s
-	rm main-bped.o
-	rm main-bped.out
-	rm linker.lsc
-
-#Auto-Insert into the ROM
-ifdef rom
-ifdef INSERT
-	dd if=main-bped.bin of="$(rom)" conv=notrunc seek=$(INSERT) bs=1
-	printf '$(encodedoffset)\x08' | dd of="$(rom)" conv=notrunc seek=$(BPEDpointer) bs=1
-else
-	@echo "Injection location not found!"
-	@echo "Did you forget to define 'offset'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
 endif
-else
-	@echo "File location not found!"
-	@echo "Did you forget to define 'rom'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-
-.PHONY : bped
-
-bpre : 
-	sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
-	sed 's/^    .equ    USED_GAME, GAME_BPEE/    .equ    USED_GAME, GAME_BPRE/' main.s > main-bpre.s
-	arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-bpre.out main-bpre.s
-	arm-none-eabi-ld -o main-bpre.o -T linker.lsc main-bpre.out
-	arm-none-eabi-objcopy -O binary main-bpre.o main-bpre.bin
-	rm main-bpre.s
-	rm main-bpre.o
-	rm main-bpre.out
-	rm linker.lsc
-
-#Auto-Insert into the ROM
-ifdef rom
-ifdef INSERT
-	dd if=main-bpre.bin of="$(rom)" conv=notrunc seek=$(INSERT) bs=1
-	printf '$(encodedoffset)\x08' | dd of="$(rom)" conv=notrunc seek=$(BPREpointer) bs=1
-else
-	@echo "Injection location not found!"
-	@echo "Did you forget to define 'offset'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-else
-	@echo "File location not found!"
-	@echo "Did you forget to define 'rom'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-
-.PHONY : bpre
-
-kwj6 : 
-	sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
-	sed 's/^    .equ    USED_GAME, GAME_BPEE/    .equ    USED_GAME, GAME_KWJ6/' main.s > main-kwj6.s
-	arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-kwj6.out main-kwj6.s
-	arm-none-eabi-ld -o main-kwj6.o -T linker.lsc main-kwj6.out
-	arm-none-eabi-objcopy -O binary main-kwj6.o main-kwj6.bin
-	rm main-kwj6.s
-	rm main-kwj6.o
-	rm main-kwj6.out
-	rm linker.lsc
-
-#Auto-Insert into the ROM
-ifdef rom
-ifdef INSERT
-	dd if=main-kwj6.bin of="$(rom)" conv=notrunc seek=$(INSERT) bs=1
-	@echo "Pointer location for build target kwj6 is unknown, it cannot be automatically patched."
-	@echo "Please change the pointer manually."
-else
-	@echo "Injection location not found!"
-	@echo "Did you forget to define 'offset'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-else
-	@echo "File location not found!"
-	@echo "Did you forget to define 'rom'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-
-.PHONY : bpge
-
-bpge : 
-	sed 's/^        rom     : ORIGIN = 0x08XXXXXX, LENGTH = 32M$$/        rom     : ORIGIN = 0x08$(offset), LENGTH = 32M/' linker_base.lsc > linker.lsc
-	sed 's/^    .equ    USED_GAME, GAME_BPEE/    .equ    USED_GAME, GAME_BPGE/' main.s > main-bpge.s
-	arm-none-eabi-gcc ${OPTS} -mthumb -mthumb-interwork -Dengine=1 -g -c -w -o main-bpge.out main-bpge.s
-	arm-none-eabi-ld -o main-bpge.o -T linker.lsc main-bpge.out
-	arm-none-eabi-objcopy -O binary main-bpge.o main-bpge.bin
-	rm main-bpge.s
-	rm main-bpge.o
-	rm main-bpge.out
-	rm linker.lsc
-
-#Auto-Insert into the ROM
-ifdef rom
-ifdef INSERT
-	dd if=main-bpge.bin of="$(rom)" conv=notrunc seek=$(INSERT) bs=1
-	printf '$(encodedoffset)\x08' | dd of="$(rom)" conv=notrunc seek=$(BPGEpointer) bs=1
-else
-	@echo "Injection location not found!"
-	@echo "Did you forget to define 'offset'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-else
-	@echo "File location not found!"
-	@echo "Did you forget to define 'rom'?"
-	@echo "Ex: make <game id> rom=<game.gba> offset=<offset in hex>"
-endif
-
-.PHONY : bpge

--- a/main.s
+++ b/main.s
@@ -6,7 +6,7 @@
     .equ    GAME_BPGE, 3
     .equ    GAME_KWJ6, 4
 
-    .equ    USED_GAME, GAME_BPEE                @ CHOOSE YOUR GAME
+    .equ    USED_GAME, GAME_SELECTION                @ CHOOSE YOUR GAME
 
     .equ    FRAME_LENGTH_5734, 0x60
     .equ    FRAME_LENGTH_7884, 0x84


### PR DESCRIPTION
Changed ".equ    USED_GAME, GAME_BPEE" to .equ    USED_GAME,
GAME_SELECTION" in main.s so Makefile does not have to filter for bpee
target.
Made single target seeing that bpee, bped, bpeg, bpre and kwj6 rules
shared mostly the same commands excepting the rule name, replacing with
$@.
GAME_SELECTION sed command is handled by variable $(shell echo $@ | tr
a-z A-Z), which converts the target to uppercase.
Single rm command with sh's {} expansion.
Single line error messages.
CURRENT_GOAL definition to filter specific targets. This is used to
display an error when building for kwj6 target.
Seeing that $(encodedoffset) is used just once and within an $(offset)
check, it was replaced on site. Likewise for $(INSERT).
"seek=___pointer" was replaced by expanded variable $($(shell echo $@ |
tr a-z A-Z)pointer) .
